### PR TITLE
added build.boot for optional Boot setup

### DIFF
--- a/Clojure/build.boot
+++ b/Clojure/build.boot
@@ -1,0 +1,19 @@
+(set-env!
+  :dependencies '[[org.clojure/clojure "1.6.0"]
+                  [org.clojure/clojurescript "0.0-3030"]
+                  [adzerk/boot-cljs "0.0-3308-0"]
+                  [com.github.rickyclarkson/jmdns "3.4.2-r353-1"]
+                  [org.omcljs/ambly "0.6.0"]])
+
+(require
+ '[adzerk.boot-cljs :refer [cljs]]
+ '[ambly.core :as ambly])
+
+(deftask ambly []
+  (task-options!
+    repl {:eval '(do
+                  (require '[cljs.repl :as repl]
+                           '[ambly.core :as ambly])
+                  (repl/repl (ambly/repl-env)))
+         })
+  (repl))

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pod "Ambly", "~> 0.6.0"
 ### Prerequisites
 
 You must have Xcode installed as well as support for [CocoaPods](http://cocoapods.org). 
-You must have Java 7 or later installed along with [Leiningen](http://leiningen.org).
+You must have Java 7 or later installed along with [Leiningen](http://leiningen.org) or [Boot](http://boot-clj.com/).
 
 ### Demo App
 
@@ -30,7 +30,7 @@ Open `Ambly Demo.xcworkspace` in Xcode and run the app in the simulator or on a 
 
 ### REPL
 
-In `ambly/Clojure` run `script/repl` to start the REPL.
+In `ambly/Clojure` run `script/repl` to start the REPL if you're using Leiningen. If you're using Boot, run `$ boot ambly`. 
 
 Here is a sample REPL startup sequence, illustrating device auto-discovery:
 


### PR DESCRIPTION
Issue discussing this PR: https://github.com/omcljs/ambly/issues/94

I've started using Ambly in a Boot development environment, and I've written a small Boot task to get Ambly up and running. I figure there are other people interested in doing the same thing, and having the Boot setup along with the Leiningen setup in the repo might help.
