### PR TITLE
Remove _Nullable annotation

### DIFF
--- a/ObjectiveC/src/ABYUtils.m
+++ b/ObjectiveC/src/ABYUtils.m
@@ -52,7 +52,7 @@ JSValueRef BlockFunctionCallAsFunction(JSContextRef ctx, JSObjectRef function, J
     }
     
     JSObjectRef jsObj = JSObjectMake(context, jsBlockFunctionClass, (void*)CFBridgingRetain(block));
-    CFBridgingRelease((__bridge CFTypeRef _Nullable)(block));
+    CFBridgingRelease((__bridge CFTypeRef)(block));
     return jsObj;
 }
 


### PR DESCRIPTION
since it is introduced in Xcode 7 and ambly needs to support other libraries which use Xcode 6, i.e Natal.
